### PR TITLE
collectors/socket - always return status + timeout

### DIFF
--- a/collectors/socket/lib/panoptimon-collector-socket/socket.rb
+++ b/collectors/socket/lib/panoptimon-collector-socket/socket.rb
@@ -25,9 +25,9 @@ module Panoptimon
       def run
         out = begin
           a = Timeout::timeout(timeout.to_i) { get_banner }
-          {status: a.match(match) ? true : false}
+          {status: a.match(match) ? true : false, timeout: false}
         rescue Timeout::Error
-          {timeout: true}
+          {timeout: true, status: false}
         end
 
         out


### PR DESCRIPTION
Panoptimon metrics are persistent.  If a collector does not return a metric on a given run, it's assumed that the value of that metric did not change.  e.g. in the metrics_http plugin -- this allows multiple collectors to contribute metrics to the same name, but does require that you e.g. clear the 'success' metric when returning a timeout condition (and clear the timeout metric if you have a success condition.)