### PR TITLE
plugins/riemann_stream/riemann_stream.rb - retry

### DIFF
--- a/plugins/riemann_stream/riemann_stream.rb
+++ b/plugins/riemann_stream/riemann_stream.rb
@@ -6,18 +6,34 @@ c = Riemann::Client.new(
   port: config[:port] || 5555,
 )
 
+# Try to connect, but no big deal / don't try too hard.
+# Riemann is only as reliable as UDP.
+5.times do |i|
+  sleep(0.25) if i > 0
+  begin
+    c['false'] # is the fastest query?
+    break
+  rescue
+  end
+end and monitor.logger.warn("Cannot connect to riemann #{c.host}:#{c.port}.  Maybe later?")
+
 hostname = config[:hostname] || Socket.gethostname
 
 ->(metrics) {
-  c.send_maybe_recv(Riemann::Message.new(:events =>
-    metrics.keys.map {|k|
-      v = metrics[k]
-      v = v.respond_to?(:to_f) ? v.to_f : v ? 1 : 0
-      Riemann::Event.new(
-        host:    hostname,
-        service: k, metric:  v,
-        # TODO tags,description,ttl,state configurable?
-      )
-    }
-  ))
+
+  msg = Riemann::Message.new(:events => metrics.keys.map {|k|
+    v = metrics[k]
+    v = v.respond_to?(:to_f) ? v.to_f : v ? 1 : 0
+    Riemann::Event.new(
+      host:    hostname,
+      service: k, metric:  v,
+      # TODO tags,description,ttl,state configurable?
+    )
+  })
+  begin
+    c.send_maybe_recv(msg)
+  rescue
+    # udp never fails, so treat tcp the same for consistency
+    # checking on riemann's health needs to happen elsewhere
+  end
 }


### PR DESCRIPTION
Trap and ignore TCP errors:  UDP gives zero feedback, but TCP will throw
a fatal error -> just ignore TCP errors as there's no point complaining
since it only uses TCP for big messages (a coincidentally big message
does not make one failure more significant than the other.)

Attempt a connection, log a warning if riemann server isn't available at
startup.  Later sends will automatically attempt to connect/reconnect.